### PR TITLE
Support older RSpec

### DIFF
--- a/json-matchers.gemspec
+++ b/json-matchers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("json-schema", ">= 1.2.1")
+  spec.add_dependency("json-schema", "~> 2.2.5")
   spec.add_dependency("activesupport", '>= 3.0.0')
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/lib/json/matchers/rspec.rb
+++ b/lib/json/matchers/rspec.rb
@@ -52,12 +52,22 @@ if RSpec.respond_to?(:configure)
       matcher.matches?(response)
     end
 
-    failure_message do |response|
-      matcher.failure_message(response)
-    end
+    if respond_to?(:failure_message)
+      failure_message do |response|
+        matcher.failure_message(response)
+      end
 
-    failure_message_when_negated do |response|
-      matcher.failure_message_when_negated(response)
+      failure_message_when_negated do |response|
+        matcher.failure_message_when_negated(response)
+      end
+    else
+      failure_message_for_should do |response|
+        matcher.failure_message(response)
+      end
+
+      failure_message_for_should_not do |response|
+        matcher.failure_message_when_negated(response)
+      end
     end
   end
 end


### PR DESCRIPTION
* Falls back to `failure_message_for_should` and
 `failure_message_for_should_not`
* Pegs `json-schema` version